### PR TITLE
Make Dockefile compatible with Docker version 17.06.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 # Building a deployment bundle
 FROM gradle:4.10 as builder
-COPY --chown=gradle:gradle . /home/gradle/src
+
+COPY . /home/gradle/src
+USER root
+RUN chown -R gradle:gradle /home/gradle/src
+USER ${ENTRYPOINT_UID}
+
 WORKDIR /home/gradle/src
 RUN gradle build
 


### PR DESCRIPTION
Docker 17.06 is the version that the Gateway officially supports.

`--chown` feature is not supported in 17.06.